### PR TITLE
CSVダウンロード時にフィールド名が重複して出力されるのを調整

### DIFF
--- a/src/csvDelete.js
+++ b/src/csvDelete.js
@@ -1,0 +1,23 @@
+window.addEventListener('DOMContentLoaded', function () {
+
+  function deleteCSV() {
+    if (window.confirm(`登録している情報を削除しますか？`)) {
+      const sortableItems = document.querySelectorAll('.sortable-item:not(.item-template)');
+      for (let index = 0; index < sortableItems.length; index += 1) {
+        sortableItems[index].remove();
+      }
+    }
+  }
+  function CsvButtonAdded() {
+    const refBtn = document.getElementsByClassName("item-insert")[0];
+    const parentTd = refBtn.parentElement;
+    const deleteButton = document.createElement("button");
+    deleteButton.setAttribute("type", "button");
+    deleteButton.setAttribute("class", "csvDownload");
+    deleteButton.setAttribute("id", "delete");
+    deleteButton.innerHTML += "登録情報削除";
+    parentTd.insertBefore(deleteButton, refBtn.nextElementSibling);
+    deleteButton.addEventListener("click", deleteCSV, false);
+  }
+  CsvButtonAdded();
+});

--- a/src/csvDownload.js
+++ b/src/csvDownload.js
@@ -19,7 +19,7 @@ window.addEventListener('DOMContentLoaded', function () {
     //すべてを格納する配列
     const prevFormDatas = [];
     //もともとのフォームのキー
-    const keys = [];
+    let keys = [];
     preElement.forEach((prev) => {
       const preform = prev.querySelectorAll("input,select,textarea");
       //一つのフォームごとの入力値を格納する配列
@@ -62,6 +62,7 @@ window.addEventListener('DOMContentLoaded', function () {
       })
       prevFormDatas.push(formValue)
     })
+    keys = keys.filter((element, index) => keys.indexOf(element) === index);
     prevFormDatas.unshift(keys);
     return prevFormDatas;
   }


### PR DESCRIPTION
いつもお世話になっております。
登録済みのカスタムフィールドグループをダウンロードするときに、
フィールド名が登録している数だけ出力される現象がありましたので、
プルリクエストさせていただきます🙏

また、CSVファイルアップロード時は「置換」ではなく「追加」かと思うのですが、
「置換」で対応したい場合がありましたので、
削除ボタンを追加させていただきました。
（違うプルリクエストにしたほうがよかったかも）

すみませんが、ご検討いただけますと幸いです。